### PR TITLE
Fix bugThere's no message displayed when component loaded

### DIFF
--- a/src/Dropify.vue
+++ b/src/Dropify.vue
@@ -256,7 +256,7 @@ export default {
 
 		setImageSrc() {
 			const src = this.src === undefined || this.src === null ? '' : this.src;
-			this.images = { src }
+			this.images = src === '' ? {} : { src }
 		},
 
 		initFileReader(index, callback) { // init file upload to dropify


### PR DESCRIPTION
**Root cause**
 As you said in the bug

**Solution**
 We should not initialized this.images if the src is invalid (empty string)